### PR TITLE
Feature/52 create community api

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,6 +1,7 @@
 import os
 import time
-from datetime import timezone, timedelta, datetime
+from datetime import datetime, timedelta, timezone
+
 from pydantic_settings import BaseSettings
 
 os.environ["TZ"] = "Asia/Seoul"
@@ -11,6 +12,7 @@ except AttributeError:
     pass
 
 KST = timezone(timedelta(hours=9))
+
 
 class Settings(BaseSettings):
     MODE: str = os.getenv("MODE", "dev")
@@ -48,5 +50,5 @@ class Settings(BaseSettings):
         env_file_encoding = "utf-8"
         extra = "ignore"
 
+
 settings = Settings()
-ADMIN_ROLES = ["점장", "매니저", "바이저"]

--- a/app/modules/community/models.py
+++ b/app/modules/community/models.py
@@ -1,15 +1,7 @@
 from enum import Enum as PyEnum
 
-from sqlalchemy import (
-    Boolean,
-    Column,
-    DateTime,
-    Enum,
-    ForeignKey,
-    Integer,
-    String,
-    Text,
-)
+from sqlalchemy import (Boolean, Column, DateTime, Enum, ForeignKey, Integer,
+                        String, Text)
 from sqlalchemy.orm import relationship
 
 from app.core.config import settings
@@ -56,7 +48,12 @@ class Post(Base):
     )
 
     author = relationship("User", back_populates="posts")
-    comments = relationship("Comment", back_populates="post")
+    comments = relationship(
+        "Comment",
+        back_populates="post",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
 
     def __repr__(self):
         short_title = (
@@ -76,7 +73,7 @@ class Comment(Base):
     id = Column(Integer, primary_key=True, index=True)
     post_id = Column(
         Integer,
-        ForeignKey("community_post.id"),
+        ForeignKey("community_post.id", ondelete="CASCADE"),
         nullable=False,
         comment="대상 게시글 id",
     )

--- a/app/modules/community/permissions.py
+++ b/app/modules/community/permissions.py
@@ -1,0 +1,93 @@
+from app.utils.permission_utils import is_admin, is_staff, is_system
+
+from .models import CategoryEnum
+
+
+def can_write_post(user, category: CategoryEnum) -> bool:
+    """
+    게시글 작성 권한
+    """
+    # 출근용 계정 접근 불가
+    if is_system(user):
+        return False
+
+    # 공지사항은 관리자만
+    if category == CategoryEnum.notice:
+        return is_admin(user)
+
+    # 교대, 휴무는 자동생성
+    if category in (CategoryEnum.shift, CategoryEnum.dayoff):
+        return False
+
+    # 자유게시판은 출근용 제외 모두
+    if category == CategoryEnum.free_board:
+        return is_admin(user) or is_staff(user)
+
+    return False
+
+
+def can_update_post(user, post_author_id: int) -> bool:
+    """
+    게시글 수정 권한
+    """
+    # 출근용 계정 접근 불가
+    if is_system(user):
+        return False
+
+    # 작성자만
+    return user.id == post_author_id
+
+
+def can_delete_post(user, post_author_id: int, category: CategoryEnum) -> bool:
+    """
+    게시글 삭제 권한
+    """
+    # 출근용 계정 접근 불가
+    if is_system(user):
+        return False
+
+    # 공지, 교대(대타), 휴무는 관리자만 삭제 가능
+    if category in (CategoryEnum.notice, CategoryEnum.shift, CategoryEnum.dayoff):
+        return is_admin(user)
+
+    # 자유게시판은 관리자, 작성자
+    if category == CategoryEnum.free_board:
+        return is_admin(user) or (user.id == post_author_id)
+
+    return False
+
+
+def can_write_comment(user):
+    """
+    댓글 작성 권한
+    """
+    # 출근용 계정 제외 모두 가능
+    return not is_system(user)
+
+
+def can_update_comment(user, comment_author_id: int):
+    """
+    댓글 수정 권한
+    """
+    # 출근용 계정 접근 불가
+    if is_system(user):
+        return False
+
+    # 댓글 작성자만
+    return user.id == comment_author_id
+
+
+def can_delete_comment(user, comment_author_id: int):
+    """
+    댓글 삭제 권한
+    """
+    # 출근용 계정 접근 불가
+    if is_system(user):
+        return False
+
+    # 관리자도 댓글 삭제 가능
+    if is_admin(user):
+        return True
+
+    # 댓글 작성자
+    return user.id == comment_author_id

--- a/app/modules/community/routers.py
+++ b/app/modules/community/routers.py
@@ -1,8 +1,103 @@
-from fastapi import APIRouter
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.security import get_current_user
+from app.modules.community import services
+from app.modules.community.models import CategoryEnum
+from app.modules.community.schemas import (CommentCreate, CommentResponse,
+                                           CommentUpdate, PostCreate,
+                                           PostResponse, PostUpdate)
+from app.utils.permission_utils import is_system
 
 router = APIRouter()
 
 
-@router.get("/")
-def get_community():
-    return {"message": "Hello World"}
+# 출근용 계정 차단
+def get_community_user(user=Depends(get_current_user)):
+    if is_system(user):
+        raise HTTPException(403, "출근용 계정은 커뮤니티 기능을 사용할 수 없습니다.")
+    return user
+
+
+# 게시글 API -----
+@router.post("/posts", response_model=PostResponse, summary="게시글 생성")
+def create_post(
+    data: PostCreate,
+    db: Session = Depends(get_db),
+    user=Depends(get_community_user),
+):
+    return services.create_post(db, user, data)
+
+
+@router.get("/posts", response_model=list[PostResponse], summary="게시글 목록 조회")
+def list_posts(
+    category: Optional[CategoryEnum] = None,
+    db: Session = Depends(get_db),
+    user=Depends(get_community_user),
+):
+    return services.list_posts(db, category)
+
+
+@router.get("/posts/{post_id}", response_model=PostResponse, summary="게시글 상세 조회")
+def get_post(
+    post_id: int,
+    db: Session = Depends(get_db),
+    user=Depends(get_community_user),
+):
+    return services.get_post(db, post_id)
+
+
+@router.patch("/posts/{post_id}", response_model=PostResponse, summary="게시글 수정")
+def update_post(
+    post_id: int,
+    data: PostUpdate,
+    db: Session = Depends(get_db),
+    user=Depends(get_community_user),
+):
+    return services.update_post(db, user, post_id, data)
+
+
+@router.delete("/posts/{post_id}", summary="게시글 삭제")
+def delete_post(
+    post_id: int,
+    db: Session = Depends(get_db),
+    user=Depends(get_community_user),
+):
+    return services.delete_post(db, user, post_id)
+
+
+# 댓글 API -----
+@router.post(
+    "/posts/{post_id}/comments", response_model=CommentResponse, summary="댓글 생성"
+)
+def create_comment(
+    post_id: int,
+    data: CommentCreate,
+    db: Session = Depends(get_db),
+    user=Depends(get_community_user),
+):
+    return services.create_comment(db, user, post_id, data)
+
+
+@router.patch(
+    "/comments/{comment_id}", response_model=CommentResponse, summary="댓글 수정"
+)
+def update_comment(
+    comment_id: int,
+    data: CommentUpdate,
+    db: Session = Depends(get_db),
+    user=Depends(get_community_user),
+):
+    return services.update_comment(db, user, comment_id, data)
+
+
+@router.delete("/comments/{comment_id}", summary="댓글 삭제")
+def delete_comment(
+    comment_id: int,
+    db: Session = Depends(get_db),
+    user=Depends(get_community_user),
+):
+    return services.delete_comment(db, user, comment_id)

--- a/app/modules/community/schemas.py
+++ b/app/modules/community/schemas.py
@@ -1,0 +1,97 @@
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+from app.modules.auth.models import PositionEnum
+from app.modules.community.models import CategoryEnum
+
+
+class PostBase(BaseModel):
+    title: str = Field(..., max_length=255, description="게시글 제목")
+    content: str = Field(..., description="게시글 내용")
+
+
+class CommentBase(BaseModel):
+    content: str = Field(..., description="댓글 내용")
+
+
+class PostCreate(PostBase):
+    """
+    게시글 작성
+    notice: 관리자
+    shift, dayoff: 자동생성(사용자x)
+    free_board: 시스템 제외 모두
+    """
+
+    category: CategoryEnum = Field(..., description="게시글 카테고리")
+
+
+class CommentCreate(CommentBase):
+    """
+    댓글 작성: 시스템 제외 모두
+    """
+
+    pass
+
+
+class PostUpdate(BaseModel):
+    """
+    게시글 수정 (제목, 내용)
+    """
+
+    title: Optional[str] = Field(None, max_length=255, description="수정할 제목")
+    content: Optional[str] = Field(None, description="수정할 내용")
+
+
+class CommentUpdate(BaseModel):
+    """
+    댓글 수정
+    """
+
+    content: Optional[str] = Field(None, description="수정할 내용")
+
+
+class CommentResponse(BaseModel):
+    """
+    댓글 응답
+    """
+
+    id: int
+    post_id: int
+    author_id: int
+    author_name: str
+    author_position: PositionEnum
+
+    content: str
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class PostResponse(BaseModel):
+    """
+    게시글 상세조회 응답
+    """
+
+    id: int
+    category: CategoryEnum
+
+    title: str
+    content: str
+
+    author_id: int
+    author_name: str
+    author_position: PositionEnum
+
+    system_generated: bool
+    created_at: datetime
+    updated_at: datetime
+
+    # 게시글에 달린 댓글까지 포함
+    comments: List[CommentResponse] = Field(default_factory=list)
+
+    class Config:
+        orm_mode = True

--- a/app/modules/community/services.py
+++ b/app/modules/community/services.py
@@ -1,0 +1,222 @@
+from fastapi import HTTPException
+from sqlalchemy.orm import Session, joinedload
+
+from app.modules.community.models import CategoryEnum, Comment, Post
+from app.modules.community.permissions import (can_delete_comment,
+                                               can_delete_post,
+                                               can_update_comment,
+                                               can_update_post,
+                                               can_write_comment,
+                                               can_write_post)
+from app.modules.community.schemas import (CommentCreate, CommentResponse,
+                                           CommentUpdate, PostCreate,
+                                           PostResponse, PostUpdate)
+
+
+# 게시글 -----
+def create_post(db: Session, user, data: PostCreate) -> PostResponse:
+    """
+    게시글 생성
+    - 자유게시판: 모두(출근용 제외)
+    - 공지: 관리자
+    - 교대(대타)/휴무: 자동생성(사용자x)
+    """
+
+    # 권한체크
+    if not can_write_post(user, data.category):
+        raise HTTPException(403, "게시글 작성 권한이 없습니다.")
+
+    # 시스템 생성(근무교대, 휴무신청) 카테고리에 작성 금지
+    if data.category in (CategoryEnum.shift, CategoryEnum.dayoff):
+        raise HTTPException(400, "이 카테고리는 사용자가 작성할 수 없습니다.")
+
+    post = Post(
+        title=data.title,
+        content=data.content,
+        category=data.category,
+        author_id=user.id,
+        system_generated=False,  # shift/dayoff만 True
+    )
+
+    db.add(post)
+    db.commit()
+    db.refresh(post)
+
+    return _build_post_response(post)
+
+
+def get_post(db: Session, post_id: int) -> PostResponse:
+    """
+    게시글 상세 조회 (댓글포함)
+    """
+    post = (
+        db.query(Post)
+        .options(joinedload(Post.comments).joinedload(Comment.author))
+        .filter(Post.id == post_id)
+        .first()
+    )
+
+    if not post:
+        raise HTTPException(404, "게시글을 찾을 수 없습니다.")
+
+    return _build_post_response(post)
+
+
+def list_posts(db: Session, category: CategoryEnum | None = None):
+    """
+    게시글 목록 조회
+    - 카테고리별 필터링
+    - 최신순 정렬
+    """
+    query = db.query(Post)
+
+    if category:
+        query = query.filter(Post.category == category)
+
+    posts = query.order_by(Post.created_at.desc()).all()
+
+    return [_build_post_response(p) for p in posts]
+
+
+def update_post(db: Session, user, post_id: int, data: PostUpdate) -> PostResponse:
+    """
+    게시글 수정
+    """
+    post = db.query(Post).filter(Post.id == post_id).first()
+
+    if not post:
+        raise HTTPException(404, "게시글이 존재하지 않습니다.")
+
+    if not can_update_post(user, post.author_id):
+        raise HTTPException(403, "게시글 수정 권한이 없습니다.")
+
+    # 필드 업데이트
+    if data.title is not None:
+        post.title = data.title
+
+    if data.content is not None:
+        post.content = data.content
+
+    db.commit()
+    db.refresh(post)
+
+    return _build_post_response(post)
+
+
+def delete_post(db: Session, user, post_id: int):
+    """
+    게시글 삭제
+    - 작성자 또는 관리자만 삭제 가능
+    - notice/shift/dayoff는 관리자만 삭제 가능
+    """
+    post = db.query(Post).filter(Post.id == post_id).first()
+
+    if not post:
+        raise HTTPException(404, "게시글이 존재하지 않습니다.")
+
+    if not can_delete_post(user, post.author_id, post.category):
+        raise HTTPException(403, "게시글 삭제 권한이 없습니다.")
+
+    db.delete(post)
+    db.commit()
+
+    return {"message": "게시글이 삭제되었습니다."}
+
+
+# 댓글 -----
+def create_comment(
+    db: Session, user, post_id: int, data: CommentCreate
+) -> CommentResponse:
+    """
+    댓글 작성
+    - 출근용 제외 모두
+    """
+    if not can_write_comment(user):
+        raise HTTPException(403, "댓글 작성 권한이 없습니다.")
+
+    post = db.query(Post).filter(Post.id == post_id).first()
+    if not post:
+        raise HTTPException(404, "게시글을 찾을 수 없습니다.")
+
+    comment = Comment(
+        post_id=post.id,
+        author_id=user.id,
+        content=data.content,
+    )
+
+    db.add(comment)
+    db.commit()
+    db.refresh(comment)
+
+    return _build_comment_response(comment)
+
+
+def update_comment(
+    db: Session, user, comment_id: int, data: CommentUpdate
+) -> CommentResponse:
+    """
+    댓글 수정
+    """
+    comment = db.query(Comment).filter(Comment.id == comment_id).first()
+
+    if not comment:
+        raise HTTPException(404, "댓글이 존재하지 않습니다.")
+
+    if not can_update_comment(user, comment.author_id):
+        raise HTTPException(403, "댓글 수정 권한이 없습니다.")
+
+    if data.content is not None:
+        comment.content = data.content
+
+    db.commit()
+    db.refresh(comment)
+
+    return _build_comment_response(comment)
+
+
+def delete_comment(db: Session, user, comment_id: int):
+    """
+    댓글 삭제
+    """
+    comment = db.query(Comment).filter(Comment.id == comment_id).first()
+
+    if not comment:
+        raise HTTPException(404, "댓글이 존재하지 않습니다.")
+
+    if not can_delete_comment(user, comment.author_id):
+        raise HTTPException(403, "댓글 삭제 권한이 없습니다.")
+
+    db.delete(comment)
+    db.commit()
+
+    return {"message": "댓글이 삭제되었습니다."}
+
+
+# sqlalchemy Post -> pydantic PostResponse (응답 스키마 변환) -----
+def _build_post_response(post: Post) -> PostResponse:
+    return PostResponse(
+        id=post.id,
+        category=post.category,
+        title=post.title,
+        content=post.content,
+        author_id=post.author_id,
+        author_name=post.author.name,
+        author_position=post.author.position,
+        system_generated=post.system_generated,
+        created_at=post.created_at,
+        updated_at=post.updated_at,
+        comments=[_build_comment_response(c) for c in post.comments],
+    )
+
+
+def _build_comment_response(comment: Comment) -> CommentResponse:
+    return CommentResponse(
+        id=comment.id,
+        post_id=comment.post_id,
+        author_id=comment.author_id,
+        author_name=comment.author.name,
+        author_position=comment.author.position,
+        content=comment.content,
+        created_at=comment.created_at,
+        updated_at=comment.updated_at,
+    )

--- a/app/modules/payroll/routers.py
+++ b/app/modules/payroll/routers.py
@@ -5,7 +5,7 @@ from app.core.database import get_db
 from app.core.security import get_current_user
 from app.modules.auth.models import User
 from app.modules.payroll import models, schemas
-from app.utils.permission_utils import RoleChecker
+from app.utils.permission_utils import is_admin
 
 router = APIRouter(tags=["Payroll"])
 
@@ -14,7 +14,7 @@ router = APIRouter(tags=["Payroll"])
 def get_payroll_list(
     db: Session = Depends(get_db), current_user: User = Depends(get_current_user)
 ):
-    if RoleChecker.is_admin(current_user.position):
+    if is_admin(current_user.position):
         payrolls = db.query(models.Payroll).all()
     else:
         payrolls = (

--- a/app/utils/permission_utils.py
+++ b/app/utils/permission_utils.py
@@ -1,12 +1,28 @@
-from app.core.config import ADMIN_ROLES
+from app.modules.auth.models import PositionEnum
+
+ADMIN_ROLES = {
+    PositionEnum.manager,
+    PositionEnum.assistant_manager,
+    PositionEnum.advisor,
+}
+
+STAFF_ROLES = {
+    PositionEnum.leader,
+    PositionEnum.crew,
+    PositionEnum.cleaner,
+}
+
+SYSTEM_ROLES = PositionEnum.system
 
 
 # 관리자 여부
-class RoleChecker:
-    @staticmethod
-    def is_admin(position: str) -> bool:  # 관리자
-        return position in ADMIN_ROLES
+def is_admin(user) -> bool:  # 관리자
+    return user.position in ADMIN_ROLES
 
-    @staticmethod
-    def is_staff(position: str) -> bool:  # 일반
-        return position not in ADMIN_ROLES
+
+def is_staff(user) -> bool:  # 일반
+    return user.position in STAFF_ROLES
+
+
+def is_system(user) -> bool:  # 시스템
+    return user.position == SYSTEM_ROLES


### PR DESCRIPTION
## :hash: 연관된 이슈

> #52

## :memo: 작업 내용

> 직책 구분 구조 개선
- Settings의 ADMIN_ROLES 제거 -> auth 모듈의 PositionEnum 기반으로 변경
- 관리자/스태프/시스템 (ADMIN_ROLES, STAFF_ROLES, SYSTEM_ROLES)으로 세분화
- 기존 RoleChecker 클래스 제거(단순 함수화)
- 기존 RoleChecker 클래스 제거(단순 함수화)에 따른 리팩토링

> 커뮤니티 권한 관리
- 게시글(카테고리별)/댓글 권한 설정

> 댓글 cascade 설정
> 커뮤니티 api 구현

### 스크린샷 (선택)

## :speech_balloon: 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
