### PR TITLE
:bug: fix(#92): PATCH 후 응답 관계(posts.comments, comment.author) 최신화

### DIFF
--- a/app/modules/community/services.py
+++ b/app/modules/community/services.py
@@ -105,7 +105,13 @@ def update_post(db: Session, user, post_id: int, data: PostUpdate) -> PostRespon
         post.content = data.content
 
     db.commit()
-    db.refresh(post)
+    # 관계까지 포함해서 재조회
+    post = (
+        db.query(Post)
+        .options(joinedload(Post.comments).joinedload(Comment.author))
+        .filter(Post.id == post_id)
+        .first()
+    )
 
     return _build_post_response(post)
 
@@ -176,7 +182,14 @@ def update_comment(
         comment.content = data.content
 
     db.commit()
-    db.refresh(comment)
+
+    # author 관계까지 포함해서 재조회
+    comment = (
+        db.query(Comment)
+        .options(joinedload(Comment.author))
+        .filter(Comment.id == comment_id)
+        .first()
+    )
 
     return _build_comment_response(comment)
 


### PR DESCRIPTION
## :hash: 연관된 이슈

> #92 

## :memo: 작업 내용

> - db.refresh()만으로 컬럼만 갱신되던 문제 해결
> - joinedload로 관계까지 재조회하여 프론트에서 즉시 수정 내용 확인 가능

