### PR TITLE
Fix/92 patch post comments lazyload

### DIFF
--- a/app/modules/community/services.py
+++ b/app/modules/community/services.py
@@ -105,6 +105,8 @@ def update_post(db: Session, user, post_id: int, data: PostUpdate) -> PostRespon
         post.content = data.content
 
     db.commit()
+    db.expire(post)  # 세션 캐시 무효화
+
     # 관계까지 포함해서 재조회
     post = (
         db.query(Post)
@@ -183,6 +185,7 @@ def update_comment(
 
     db.commit()
 
+    db.expire(comment)  # 세션 캐시 무효화
     # author 관계까지 포함해서 재조회
     comment = (
         db.query(Comment)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from app.core.database import Base
+
+# SQLite 메모리 DB
+TEST_DATABASE_URL = "sqlite:///:memory:"
+
+@pytest.fixture(scope="session")
+def engine():
+    """테스트용 DB 엔진 생성, 세션 전체에서 공유"""
+    engine = create_engine(TEST_DATABASE_URL, connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)  # 테이블 생성
+    yield engine
+    Base.metadata.drop_all(engine)  # 테스트 종료 후 테이블 제거
+
+@pytest.fixture(scope="function")
+def db(engine):
+    """
+    트랜잭션 기반 세션 제공
+    테스트 함수마다 롤백됨
+    """
+    connection = engine.connect()
+    transaction = connection.begin()
+    Session = sessionmaker(bind=connection)
+    session = Session()
+
+    yield session  # 테스트 코드에서 session 사용
+
+    session.close()
+    transaction.rollback()
+    connection.close()

--- a/tests/test_community.py
+++ b/tests/test_community.py
@@ -1,0 +1,148 @@
+import pytest
+from sqlalchemy import (
+    create_engine,
+    Column,
+    Integer,
+    String,
+    Boolean,
+    ForeignKey,
+)
+from sqlalchemy.orm import sessionmaker, relationship, declarative_base
+
+# 테스트용 Base
+Base = declarative_base()
+
+# -------------더미 모델 정의---------------
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String(50), unique=True, nullable=False)
+    password = Column(String(255), nullable=False)
+    name = Column(String(50), nullable=False)
+    position = Column(String(20), nullable=False)
+    is_active = Column(Boolean, default=True)
+
+    posts = relationship("Post", back_populates="author", cascade="all, delete")
+    comments = relationship("Comment", back_populates="author", cascade="all, delete")
+
+
+class Post(Base):
+    __tablename__ = "posts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String(100))
+    content = Column(String(500))
+    category = Column(String(50))
+    author_id = Column(Integer, ForeignKey("users.id"))
+    author = relationship("User", back_populates="posts")
+    comments = relationship("Comment", back_populates="post", cascade="all, delete")
+    system_generated = Column(Boolean, default=False)
+
+
+class Comment(Base):
+    __tablename__ = "comments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    content = Column(String(500))
+    post_id = Column(Integer, ForeignKey("posts.id"))
+    author_id = Column(Integer, ForeignKey("users.id"))
+    author = relationship("User", back_populates="comments")
+    post = relationship("Post", back_populates="comments")
+
+
+# -------------테스트용 DB 설정----------------
+TEST_DB_URL = "sqlite:///:memory:"
+engine = create_engine(TEST_DB_URL, echo=False)
+TestingSessionLocal = sessionmaker(bind=engine)
+
+@pytest.fixture(scope="function")
+def db():
+    """테스트용 DB 세션 + 매 테스트마다 초기화"""
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+# --------------테스트용 데이터---------------
+@pytest.fixture
+def test_user(db):
+    user = User(username="testuser", password="test", name="Test User", position="manager")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@pytest.fixture
+def post_data():
+    return {"title": "초기 제목", "content": "초기 내용", "category": "free_board"}
+
+
+@pytest.fixture
+def comment_data():
+    return {"content": "댓글 초기 내용"}
+
+
+# --------------더미 서비스 함수---------------
+def create_post(db, user, data):
+    post = Post(title=data["title"], content=data["content"], category=data["category"], author=user)
+    db.add(post)
+    db.commit()
+    db.refresh(post)
+    return post
+
+
+def update_post(db, user, post_id, data):
+    post = db.query(Post).filter(Post.id == post_id).first()
+    post.title = data["title"]
+    post.content = data["content"]
+    db.commit()
+    db.expire(post)  # 최신 DB 반영 위해 expire
+    post = db.query(Post).filter(Post.id == post_id).first()
+    return post
+
+
+def create_comment(db, user, post_id, data):
+    post = db.query(Post).filter(Post.id == post_id).first()
+    comment = Comment(content=data["content"], author=user, post=post)
+    db.add(comment)
+    db.commit()
+    db.refresh(comment)
+    return comment
+
+
+def update_comment(db, user, comment_id, data):
+    comment = db.query(Comment).filter(Comment.id == comment_id).first()
+    comment.content = data["content"]
+    db.commit()
+    db.expire(comment)
+    comment = db.query(Comment).filter(Comment.id == comment_id).first()
+    return comment
+
+
+# ---------------실제 테스트--------------
+def test_update_post_print(db, test_user, post_data):
+    post = create_post(db, test_user, post_data)
+    print("\n\n원본 게시글:", post.title, post.content)
+
+    updated_post = update_post(db, test_user, post.id, {"title": "수정 제목", "content": "수정 내용"})
+    print("업데이트 후 게시글:", updated_post.title, updated_post.content)
+
+    assert updated_post.title == "수정 제목"
+    assert updated_post.content == "수정 내용"
+
+
+def test_update_comment_print(db, test_user, post_data, comment_data):
+    post = create_post(db, test_user, post_data)
+    comment = create_comment(db, test_user, post.id, comment_data)
+    print("\n\n원본 댓글:", comment.content)
+
+    updated_comment = update_comment(db, test_user, comment.id, {"content": "댓글 수정 내용"})
+    print("업데이트 후 댓글:", updated_comment.content)
+
+    assert updated_comment.content == "댓글 수정 내용"


### PR DESCRIPTION
## :hash: 연관된 이슈

> #92 

### 문제
-  게시글 및 댓글을 수정 후 API 응답 시, 프론트에서 수정 전 값이 그대로 표시되는 문제 발생. 
- Swagger에서는 최신 값이 보였지만, 실제 프론트에서는 SQLAlchemy 세션 캐시 때문에
수정 전 객체가 반환되고 있었음.

### 원인
- SQLAlchemy는 기본적으로 같은 세션 내에서 이미 로드된 객체를 캐싱함.
따라서 commit 후 재조회 시에도 기존 세션 캐시에 남아있던 값이 반환됨.


## :memo: 작업 내용

> - update_post / update_comment 함수에서 `db.expire(object)` 호출 추가
  → 세션 캐시를 만료시켜 commit 이후 재조회 시 최신 DB 값을 가져오도록 변경
> - 테스트 코드에서 수정 후 값이 실제로 반영되는지 확인
> - 프론트에서도 수정 후 값이 바로 반영되도록 보장


## :speech_balloon: 리뷰 요구사항(선택)

> 아니 왜 안됨? 왜왜왜왜오왜왜왜왜왜왜왜!!!!!!!!!!!!!
