### PR TITLE
Feature/139 category posts count api

### DIFF
--- a/app/modules/admin/routers/admin.py
+++ b/app/modules/admin/routers/admin.py
@@ -1,12 +1,11 @@
-import os
 from datetime import date
 
 import requests
-from dotenv import load_dotenv
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
 from app.core.database import get_db
 from app.core.security import get_current_admin
 from app.modules.admin import models, schemas
@@ -17,8 +16,7 @@ router = APIRouter()
 holiday_router = APIRouter()
 
 
-load_dotenv()
-HOLIDAY_API_KEY = os.getenv("HOLIDAY_API_KEY")
+HOLIDAY_API_KEY = settings.HOLIDAY_API_KEY
 
 if not HOLIDAY_API_KEY:
     raise RuntimeError("HOLIDAY_API_KEY is not set")

--- a/app/modules/community/routers.py
+++ b/app/modules/community/routers.py
@@ -19,6 +19,11 @@ from app.modules.community.schemas import (
     PostResponse,
     PostUpdate,
     SearchScope,
+    CategoryCountResponse,
+)
+from app.modules.community.services import (
+    get_category_post_counts,
+    get_all_category_post_counts,
 )
 from app.utils.permission_utils import is_system
 
@@ -30,6 +35,39 @@ def get_community_user(user=Depends(get_current_user)):
     if is_system(user):
         raise HTTPException(403, "출근용 계정은 커뮤니티 기능을 사용할 수 없습니다.")
     return user
+
+
+# 카테고리별 게시글 수 API -----
+@router.get(
+    "/category-counts",
+    response_model=CategoryCountResponse,
+    status_code=200,
+    summary="카테고리별 게시글 수",
+)
+def category_counts(
+    db: Session = Depends(get_db),
+    category: str | None = Query(
+        None, description="카테고리 이름 (공지, 근무교대, 휴무신청, 자유게시판)"
+    ),
+    user=Depends(get_community_user),
+) -> CategoryCountResponse:
+    """
+    전체 또는 카테고리별 게시글 수 조회
+    - category 파라미터 없으면 전체 + 각 카테고리 count 반환
+    - category 파라미터 있으면 해당 카테고리 count만 반환
+    """
+    if category:
+        try:
+            cat_enum = CategoryEnum(category)
+        except ValueError:
+            return {"counts": {category: 0}}  # 존재하지 않는 카테고리 0
+
+        count = get_category_post_counts(db, cat_enum)
+        return {"counts": {category: count}}
+
+    # 전체 + 카테고리별
+    counts = get_all_category_post_counts(db)
+    return {"counts": counts}
 
 
 # 게시글 API -----

--- a/app/modules/community/schemas.py
+++ b/app/modules/community/schemas.py
@@ -10,6 +10,10 @@ from app.modules.community.models import CategoryEnum
 T = TypeVar("T")
 
 
+class CategoryCountResponse(BaseModel):
+    counts: dict[str, int]
+
+
 class PostBase(BaseModel):
     title: str = Field(..., max_length=255, description="게시글 제목")
     content: str = Field(..., description="게시글 내용")

--- a/app/modules/community/services.py
+++ b/app/modules/community/services.py
@@ -27,6 +27,32 @@ from app.modules.community.schemas import (
 )
 
 
+# 카테고리 -----
+def get_category_post_counts(db: Session, category: CategoryEnum | None = None) -> int:
+    """
+    카테고리 별 게시글 수 조회
+    - category=None이면 전체 게시글 수 반환
+    """
+    query = db.query(func.count(Post.id))
+    if category:
+        query = query.filter(Post.category == category)
+    return query.scalar()
+
+
+def get_all_category_post_counts(db: Session) -> dict[str, int]:
+    """
+    모든 카테고리별 게시글 수 반환
+    """
+    counts = {}
+    total = 0
+    for cat in CategoryEnum:
+        cat_count = get_category_post_counts(db, cat)
+        counts[cat.value] = cat_count
+        total += cat_count
+    counts["전체"] = total
+    return counts
+
+
 # 게시글 -----
 def create_post(db: Session, user, data: PostCreate) -> PostResponse:
     """


### PR DESCRIPTION
## 🚀 PR 요약
<!-- 이번 PR이 무엇을 해결하는지 한 줄로 설명해주세요 -->
- 카테고리별 게시글 수를 반환하는 api 추가
- 카테고리 미 입력 시 전체 게시글 수 포함하는 전체 카테고리별 게시글 수 반환
---

## 🔗 연관 이슈
<!-- 관련된 이슈를 연결해주세요 -->


- Ref #139 Feat:  카테고리별 게시글 수 반환 api 구현
- Closes #108 Fix: HOLIDAY_API_KEY를 Settings에서 가져오도록 변경

---

## 🛠 작업 내용
<!-- 이번 PR에서 수행한 작업을 bullet point로 정리해주세요 -->
- [x] 카테고리별 게시글 수 반환 엔드포인트 추가
- [x]  HOLIDAY_API_KEY를 Settings에서 가져오도록 변경
  - FastAPI + Pydantic Settings 환경이니까 직접 os.getenv() 할 필요없음

---

## 🧪 테스트 방법
<!-- 리뷰어가 이 PR을 어떻게 테스트하면 되는지 작성 -->
- [x] 로컬 테스트 (`python manage.py test`)
- [x] GitHub Actions CI 통과 확인

---

## ⚠️ 변경으로 인한 영향 범위
<!-- 이 PR로 인해 영향을 받을 수 있는 부분 -->

- [x] 기존 기능에 영향 없음

---

## 💬 리뷰 요청 사항
<!-- 리뷰어가 집중해서 봐줬으면 하는 포인트 -->

---

## 📌 체크리스트
<!-- PR 올리기 전 스스로 확인 -->
- [x] 로컬 테스트 완료
- [x] CI 통과 확인
- [x] 불필요한 디버그 코드 제거
- [x] 문서/주석 필요 여부 검토